### PR TITLE
Redis connection spike

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ parameters:
 jobs:
   validate:
     executor:
-      docker:
-        - image: cimg/redis:6.2
       name: hmpps/java
       tag: "19.0"
     steps:
@@ -40,6 +38,8 @@ workflows:
   build-test-and-deploy:
     jobs:
       - validate:
+          docker:
+            - image: cimg/redis:6.2
           filters:
             tags:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,6 @@ jobs:
         -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2
         -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
         -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
-    parameters:
-      resource_class:
-        default: medium
-        type: string
-      tag:
-        type: string
     resource_class: medium
     working_directory: ~/app
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ parameters:
 jobs:
   validate:
     executor:
+      docker:
+        - image: cimg/redis:6.2
       name: hmpps/java
       tag: "19.0"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,22 @@ parameters:
 
 jobs:
   validate:
-    executor:
-      name: hmpps/java
-      tag: "19.0"
+    docker:
+      - image: cimg/openjdk:19.0
+      - image: cimg/redis:6.0
+    environment:
+      _JAVA_OPTIONS: >-
+        -Xmx256m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2
+        -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
+        -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+    parameters:
+      resource_class:
+        default: medium
+        type: string
+      tag:
+        type: string
+    resource_class: medium
+    working_directory: ~/app
     steps:
       - checkout
       - restore_cache:
@@ -38,8 +51,6 @@ workflows:
   build-test-and-deploy:
     jobs:
       - validate:
-          docker:
-            - image: cimg/redis:6.2
           filters:
             tags:
               ignore: /.*/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,9 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.1")
 }
 
 java {

--- a/helm_deploy/hmpps-central-session-api/values.yaml
+++ b/helm_deploy/hmpps-central-session-api/values.yaml
@@ -18,6 +18,7 @@ generic-service:
   env:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
+    REDIS_TLS_ENABLED: "true"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
@@ -30,6 +31,9 @@ generic-service:
   namespace_secrets:
     hmpps-central-session-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+    elasticache-redis:
+      REDIS_HOST: "primary_endpoint_address"
+      REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
     office: "217.33.148.210/32"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/centralsessionapi/resource/TestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/centralsessionapi/resource/TestResource.kt
@@ -6,7 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
-import org.springframework.data.redis.connection.*
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.ReactiveRedisOperations
@@ -15,10 +17,15 @@ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext.newSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
-import java.util.*
 import kotlin.collections.MutableMap
 import kotlin.collections.mutableMapOf
 import kotlin.collections.set
@@ -48,8 +55,9 @@ class TestResource(val sessionOps: ReactiveRedisOperations<String, StoredSession
     }
 
     throw ResponseStatusException(
-      HttpStatus.NOT_FOUND, "entity not found",
-    );
+      HttpStatus.NOT_FOUND,
+      "entity not found",
+    )
   }
 
   @PostMapping("/{id}/{appName}")
@@ -119,7 +127,7 @@ class RedisProperties(
   var port: Int = 6379,
   var password: String = "",
   var tlsEnabled: Boolean = false,
-) {}
+)
 
 @Configuration
 class SessionOps(val redisProperties: RedisProperties) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/centralsessionapi/resource/TestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/centralsessionapi/resource/TestResource.kt
@@ -1,0 +1,153 @@
+package uk.gov.justice.digital.hmpps.centralsessionapi.resource
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.*
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.ReactiveRedisOperations
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext.newSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.Mono
+import java.util.*
+import kotlin.collections.MutableMap
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+
+@RestController
+@RequestMapping("/sessions")
+class TestResource(val sessionOps: ReactiveRedisOperations<String, StoredSession>) {
+  val logger = LoggerFactory.getLogger(TestResource::class.java)
+
+  @GetMapping("/{id}/{appName}")
+  suspend fun read(
+    @PathVariable id: String,
+    @PathVariable appName: String,
+  ): Session {
+    val storedSession = sessionOps.opsForValue().get(id).block()
+    if (storedSession != null) {
+      return Session(
+        storedSession.cookie,
+        SessionPassport(
+          SessionPassportUser(
+            storedSession.tokens[appName],
+            storedSession.username,
+            storedSession.authSource,
+          ),
+        ),
+      )
+    }
+
+    throw ResponseStatusException(
+      HttpStatus.NOT_FOUND, "entity not found",
+    );
+  }
+
+  @PostMapping("/{id}/{appName}")
+  suspend fun setSession(
+    @PathVariable id: String,
+    @PathVariable appName: String,
+    @RequestBody session: Session,
+  ): Mono<Boolean> {
+    logger.info(session.cookie?.expires ?: "MISSING EXPIRY")
+    logger.info(session.passport?.user?.token ?: "MISSING TOKEN")
+    val storedSession: StoredSession = sessionOps.opsForValue().get(id).block() ?: StoredSession(
+      session.cookie,
+      mutableMapOf(),
+      session.passport?.user?.username,
+      session.passport?.user?.authSource,
+    )
+
+    if (session.passport?.user?.token != null) {
+      storedSession.tokens[appName] = session.passport.user.token
+    }
+
+    return sessionOps.opsForValue().set(id, storedSession)
+  }
+
+  @DeleteMapping("/{id}/{appName}")
+  suspend fun delete(
+    @PathVariable id: String,
+    @PathVariable appName: String,
+  ) = sessionOps.delete(id)
+}
+
+class SessionCookie(
+  @JsonProperty("originalMaxAge") val originalMaxAge: Number,
+  @JsonProperty("expires") val expires: String,
+  @JsonProperty("secure") val secure: Boolean,
+  @JsonProperty("httpOnly") val httpOnly: Boolean,
+  @JsonProperty("path") val path: String,
+  @JsonProperty("sameSite") val sameSite: String,
+)
+
+class StoredSession(
+  @JsonProperty("cookie") val cookie: SessionCookie?,
+  @JsonProperty("tokens") val tokens: MutableMap<String, String>,
+  @JsonProperty("username") val username: String?,
+  @JsonProperty("authSource") val authSource: String?,
+)
+
+class SessionPassportUser(
+  val token: String?,
+  val username: String?,
+  val authSource: String?,
+)
+
+class SessionPassport(
+  val user: SessionPassportUser?,
+)
+
+class Session(
+  val cookie: SessionCookie?,
+  val passport: SessionPassport?,
+)
+
+@Configuration
+@ConfigurationProperties(prefix = "redis")
+class RedisProperties(
+  var host: String = "localhost",
+  var port: Int = 6379,
+  var password: String = "",
+  var tlsEnabled: Boolean = false,
+) {}
+
+@Configuration
+class SessionOps(val redisProperties: RedisProperties) {
+  @Bean
+  @Primary
+  fun reactiveRedisConnectionFactory(): ReactiveRedisConnectionFactory {
+    val config = RedisStandaloneConfiguration()
+    config.hostName = redisProperties.host
+    config.port = redisProperties.port
+    config.password = if (redisProperties.password.isEmpty()) {
+      RedisPassword.none()
+    } else {
+      RedisPassword.of(redisProperties.password)
+    }
+
+    val clientConfigBuilder = LettuceClientConfiguration.builder()
+    if (redisProperties.tlsEnabled) clientConfigBuilder.useSsl()
+
+    return LettuceConnectionFactory(config, clientConfigBuilder.build())
+  }
+
+  @Bean
+  fun redisOperations(
+    connectionFactory: ReactiveRedisConnectionFactory,
+  ): ReactiveRedisOperations<String, StoredSession> {
+    val serializer = Jackson2JsonRedisSerializer(StoredSession::class.java)
+    val builder = newSerializationContext<String, StoredSession>(StringRedisSerializer())
+    val context = builder.value(serializer).build()
+    return ReactiveRedisTemplate(connectionFactory, context)
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,9 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+redis:
+  host: ${REDIS_HOST:localhost}
+  port: ${REDIS_PORT:6379}
+  password: ${REDIS_AUTH_TOKEN}
+  tls-enabled: ${REDIS_TLS_ENABLED:false}


### PR DESCRIPTION
Maps the 3 main routes (get/set/delete) to a Redis repo using Reactive Redis

It would be good to get this deployed as the POC app is complicated to set up with this API running locally due to it running inside docker without access to the host - so I'm opening the PR as it stands at the moment and we can re-do it if it ends up working correctly